### PR TITLE
Pass additional parameters to daemon

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -1,9 +1,10 @@
 define osrm::instance (
   $data_dir,
-  $ensure  = 'present',
-  $threads = 8,
-  $ip      = '127.0.0.1',
-  $port    = '5000',
+  $ensure          = 'present',
+  $threads         = 8,
+  $ip              = '127.0.0.1',
+  $port            = '5000',
+  $additional_args = '-e 1',
 ) {
 
   $service_name = "osrm-${name}"

--- a/templates/init.erb
+++ b/templates/init.erb
@@ -16,7 +16,7 @@ DESC="high performance routing engine"
 NAME=osrm-<%= @name %>
 USER=osrm
 DAEMON=/usr/bin/osrm-routed
-DAEMON_ARGS="<%= @data_dir %>/<%= @name %>.osrm -i <%= @ip %> -p <%= @port %> -t <%= @threads %> -e 1"
+DAEMON_ARGS="<%= @data_dir %>/<%= @name %>.osrm -i <%= @ip %> -p <%= @port %> -t <%= @threads %> <%= @additional_args %>"
 LOGFILE=/var/log/osrm/$NAME.log
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME


### PR DESCRIPTION
Allows to pass '-e 1' (default) when requiring elevation on a patched
build. Or empty when using upstream version.

Backward compatible change.
